### PR TITLE
distribute license file with source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include src/cfisher.pyx
 include README.rst
+include LICENSE
 include versioneer.py
 include fisher/_version.py


### PR DESCRIPTION
As a follow-up to https://github.com/brentp/fishers_exact_test/issues/21, I've added the license file to the `MANIFEST.in` so that it is distributed with the source as is specified by the BSD. 