### PR TITLE
Make `setup.py` cythonize the extensions when building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-fisher/cfisher.so
+fisher/*.so
 build/
 dist/
 *.pyc

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class _build_ext(build_ext):
 
         # Cythonize the extension (and path the `_needs_stub` attribute,
         # which is not set by Cython but required by `setuptools`)
-        self.extensions = cythonize(self.extensions)
+        self.extensions = cythonize(self.extensions, force=self.force)
         for extension in self.extensions:
             extension._needs_stub = False
 

--- a/setup.py
+++ b/setup.py
@@ -7,25 +7,32 @@ from setuptools.extension import Extension
 
 
 class _build_ext(build_ext):
-    """build_ext command for use when numpy headers are needed.
+    """build_ext command for use when numpy and Cython are needed.
 
     https://stackoverflow.com/a/42163080/8083313
+
     """
 
     def run(self):
-
-        # Import numpy here, only when headers are needed
+        # Only resolve imports when they are absolutely needed
         import numpy
+        from Cython.Build import cythonize
 
         # Add numpy headers to include_dirs
         self.include_dirs.append(numpy.get_include())
+
+        # Cythonize the extension (and path the `_needs_stub` attribute,
+        # which is not set by Cython but required by `setuptools`)
+        self.extensions = cythonize(self.extensions)
+        for extension in self.extensions:
+            extension._needs_stub = False
 
         # Call original build_ext command
         build_ext.run(self)
 
 
 doc = open("README.md").read()
-cfisher_ext = Extension("fisher.cfisher", ["src/cfisher.c"], extra_compile_args=["-O3"])
+cfisher_ext = Extension("fisher.cfisher", ["src/cfisher.pyx"], extra_compile_args=["-O3"])
 cmdclass = {"build_ext": _build_ext}
 cmdclass.update(versioneer.get_cmdclass())
 
@@ -42,7 +49,7 @@ setup_options = dict(
     ext_modules=[cfisher_ext],
     cmdclass=cmdclass,
     #       install_requires=['numpy'],
-    setup_requires=["numpy"],
+    setup_requires=["numpy", "cython"],
     keywords="statistics cython",
     license="BSD",
     packages=["fisher"],


### PR DESCRIPTION
As discussed in #36 this PR implements automatic cythonization of the `fisher.cfisher` extension when `python setup.py install` or `pip install` is being executed.

I unstaged + `.gitignore`'d the C file because it's not needed anymore, a new one will be generated at any time so there is no point version-tracking it.