### PR TITLE
Add `pyproject.toml` to fix `pip` install of setup dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include README.rst
 include LICENSE
 include versioneer.py
 include fisher/_version.py
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "cython", "numpy"]
+build-backend = "setuptools.build_meta"
+


### PR DESCRIPTION
Hi @brentp !

This small PR adds a [`pyproject.toml`](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/) file to the repository, which can be used to instruct `pip` about the required setup dependencies when building `fisher`. This should fix #39, as `pip` would be able to figure out the build dependencies in advance thanks to this metadata file.

By the way, would you be interested in distributing wheels for the package? I would be happy to write a PR with GitHub Actions to compile the package for different targets using `cibuildwheel`, so that users don't have to compile on every install. 