### PR TITLE
Fix `versioneer` prefix in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,10 @@ VCS = git
 style = pep440-pre
 versionfile_source = fisher/_version.py
 versionfile_build = fisher/_version.py
-tag_prefix =
+tag_prefix = v
 
 [options]
 packages = find:
 zip_safe = True
 include_package_data = True
-install_requires =
-    numpy
-	pytest
-    versioneer
+install_requires = numpy


### PR DESCRIPTION
Okay I found the bug, `versioneer` uses a glob pattern to identify tags which seems to fail if the `tag_prefix` key is empty. I did a test run on my end and now the wheels have the proper tag.