### PR TITLE
Pin `gh-action-pypi-publish` version in `package.yml`

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -250,7 +250,7 @@ jobs:
       with:
         name: wheels
         path: dist
-    - uses: pypa/gh-action-pypi-publish@master
+    - uses: pypa/gh-action-pypi-publish@release/v1
       if: startsWith(github.ref, 'refs/tags')
       with:
         user: __token__


### PR DESCRIPTION
Fix some warnings in CI.