### PR TITLE
Fix package.yml CI failures (should fix the package issue)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,7 @@ jobs:
         CIBW_ARCHS: aarch64
         CIBW_BUILD: ${{ matrix.python-tag }}
         CIBW_BUILD_VERBOSITY: 2
+        CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux2014_aarch64:2026.04.24-1
         CIBW_BEFORE_BUILD: pip install cython pytest
         CIBW_TEST_COMMAND: python -c "import fisher"
         CIBW_TEST_REQUIRES: importlib-resources
@@ -67,6 +68,7 @@ jobs:
       env:
         CIBW_ARCHS: x86_64
         CIBW_BUILD: ${{ matrix.python-tag }}
+        CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:2026.04.24-1
         CIBW_BEFORE_BUILD: pip install cython pytest
         CIBW_BUILD_VERBOSITY: 2
         CIBW_BEFORE_TEST: "git status && ls -lh"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - v*
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
 
   wheel-linux-aarch64:
@@ -23,13 +20,13 @@ jobs:
         - cp312-manylinux_aarch64
         - cp313-manylinux_aarch64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       with:
         platforms: all
     - name: Build manylinux wheels
@@ -44,7 +41,7 @@ jobs:
         CIBW_TEST_REQUIRES: importlib-resources
       with:
         output-dir: dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
@@ -62,7 +59,7 @@ jobs:
         - cp312-manylinux_x86_64
         - cp313-manylinux_x86_64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
@@ -79,7 +76,7 @@ jobs:
         CIBW_TEST_REQUIRES: importlib-resources
       with:
         output-dir: dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
@@ -97,7 +94,7 @@ jobs:
         - cp312-macosx_x86_64
         - cp313-macosx_x86_64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
@@ -112,7 +109,7 @@ jobs:
         CIBW_TEST_REQUIRES: importlib-resources
       with:
         output-dir: dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
@@ -128,7 +125,7 @@ jobs:
         - cp312-macosx_arm64
         - cp313-macosx_arm64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         submodules: true
@@ -143,7 +140,7 @@ jobs:
         CIBW_TEST_REQUIRES: importlib-resources
       with:
         output-dir: dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
@@ -161,7 +158,7 @@ jobs:
         - cp312-win_amd64
         - cp313-win_amd64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
@@ -176,7 +173,7 @@ jobs:
         CIBW_TEST_REQUIRES: importlib-resources
       with:
         output-dir: dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
@@ -185,12 +182,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Build source distribution
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
     - name: Install build requirements
@@ -198,7 +195,7 @@ jobs:
     - name: Build source distribution
       run: python setup.py sdist
     - name: Store built source distribution
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sdist
         path: dist/*
@@ -210,7 +207,7 @@ jobs:
     - sdist
     steps:
     - name: Setup Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Download built sdist

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,6 +18,7 @@ jobs:
         - cp310-manylinux_aarch64
         - cp311-manylinux_aarch64
         - cp312-manylinux_aarch64
+        - cp313-manylinux_aarch64
     steps:
     - uses: actions/checkout@v4
       with:
@@ -25,7 +26,7 @@ jobs:
         fetch-depth: 0
     - name: Set up QEMU
       id: qemu
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: all
     - name: Build manylinux wheels
@@ -55,15 +56,12 @@ jobs:
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
         - cp312-manylinux_x86_64
+        - cp313-manylinux_x86_64
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.23.1
       env:
@@ -83,7 +81,7 @@ jobs:
 
   wheel-macos-x86_64:
     name: Build MacOS wheels (x86-64)
-    runs-on: macOS-11
+    runs-on: macos-13
     strategy:
       matrix:
         python-tag:
@@ -92,15 +90,12 @@ jobs:
         - cp310-macosx_x86_64
         - cp311-macosx_x86_64
         - cp312-macosx_x86_64
+        - cp313-macosx_x86_64
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.23.1
       env:
@@ -119,25 +114,19 @@ jobs:
 
   wheel-macos-aarch64:
     name: Build MacOS wheels (Aarch64)
-    runs-on: macOS-11
+    runs-on: macos-14
     strategy:
       matrix:
         python-tag:
-        - cp38-macosx_arm64
-        - cp39-macosx_arm64
         - cp310-macosx_arm64
         - cp311-macosx_arm64
         - cp312-macosx_arm64
+        - cp313-macosx_arm64
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         submodules: true
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-        target: aarch64-apple-darwin
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.23.1
       env:
@@ -165,15 +154,12 @@ jobs:
         - cp310-win_amd64
         - cp311-win_amd64
         - cp312-win_amd64
+        - cp313-win_amd64
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.23.1
       env:
@@ -209,7 +195,7 @@ jobs:
     - name: Store built source distribution
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.python-tag }}
+        name: sdist
         path: dist/*
 
   test-sdist:
@@ -222,10 +208,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    - name: Download built wheels
+    - name: Download built sdist
       uses: actions/download-artifact@v4
       with:
-          name: wheels-${{ matrix.python-tag }}
+          name: sdist
           path: dist/
     - name: Update pip to latest version
       run: python -m pip install -U pip setuptools wheel pytest
@@ -251,7 +237,12 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: wheels
+        pattern: wheels-*
+        merge-multiple: true
+        path: dist
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdist
         path: dist
     - uses: pypa/gh-action-pypi-publish@release/v1
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -211,7 +211,7 @@ jobs:
       with:
         python-version: '3.12'
     - name: Download built sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
           name: sdist
           path: dist/
@@ -237,12 +237,12 @@ jobs:
     - wheel-macos-x86_64
     - wheel-win32-x86_64
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         pattern: wheels-*
         merge-multiple: true
         path: dist
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: sdist
         path: dist

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   wheel-linux-aarch64:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,7 +9,7 @@ jobs:
 
   wheel-linux-aarch64:
     name: Build Linux wheels (Aarch64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         python-tag:
@@ -24,11 +24,6 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-    - name: Set up QEMU
-      id: qemu
-      uses: docker/setup-qemu-action@v4
-      with:
-        platforms: all
     - name: Build manylinux wheels
       uses: pypa/cibuildwheel@v2.23.1
       env:
@@ -147,7 +142,7 @@ jobs:
 
   wheel-win32-x86_64:
     name: Build Windows wheels (x86-64)
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         python-tag:
@@ -179,7 +174,7 @@ jobs:
         path: dist/*
 
   sdist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Build source distribution
     steps:
     - uses: actions/checkout@v6
@@ -201,7 +196,7 @@ jobs:
         path: dist/*
 
   test-sdist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Test source distribution
     needs:
     - sdist
@@ -226,7 +221,7 @@ jobs:
 
   upload:
     environment: PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Upload
     needs:
     - sdist

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -84,12 +84,12 @@ jobs:
     strategy:
       matrix:
         python-tag:
-          #- cp38-macosx_x86_64
-          #- cp39-macosx_x86_64
-          #- cp310-macosx_x86_64
-          #- cp311-macosx_x86_64
+        #- cp38-macosx_x86_64
+        #- cp39-macosx_x86_64
+        #- cp310-macosx_x86_64
+        #- cp311-macosx_x86_64
         - cp312-macosx_x86_64
-          #- cp313-macosx_x86_64
+        #- cp313-macosx_x86_64
     steps:
     - uses: actions/checkout@v6
       with:
@@ -111,8 +111,8 @@ jobs:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
 
-  wheel-macos-aarch64:
-    name: Build MacOS wheels (Aarch64)
+  wheel-macos-aarch64-m14:
+    name: Build MacOS wheels (Aarch64, macos-14)
     runs-on: macos-14
     strategy:
       matrix:
@@ -143,8 +143,8 @@ jobs:
         name: wheels-${{ matrix.python-tag }}
         path: dist/*
 
-  wheel-macos-aarch64:
-    name: Build MacOS wheels (Aarch64)
+  wheel-macos-aarch64-m15:
+    name: Build MacOS wheels (Aarch64, macos-15)
     runs-on: macos-15
     strategy:
       matrix:
@@ -264,7 +264,8 @@ jobs:
     - test-sdist
     - wheel-linux-aarch64
     - wheel-linux-x86_64
-    - wheel-macos-aarch64
+    - wheel-macos-aarch64-m14
+    - wheel-macos-aarch64-m15
     - wheel-macos-x86_64
     - wheel-win32-x86_64
     steps:
@@ -283,4 +284,3 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
         skip_existing: true
-

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build manylinux wheels
-      uses: pypa/cibuildwheel@v2.23.1
+      uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_ARCHS: aarch64
         CIBW_BUILD: ${{ matrix.python-tag }}
@@ -59,7 +59,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build manylinux wheels
-      uses: pypa/cibuildwheel@v2.23.1
+      uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_ARCHS: x86_64
         CIBW_BUILD: ${{ matrix.python-tag }}
@@ -94,7 +94,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build manylinux wheels
-      uses: pypa/cibuildwheel@v2.23.1
+      uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_ARCHS: x86_64
         CIBW_BUILD: ${{ matrix.python-tag }}
@@ -125,7 +125,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - name: Build manylinux wheels
-      uses: pypa/cibuildwheel@v2.23.1
+      uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_ARCHS: arm64
         CIBW_BUILD: ${{ matrix.python-tag }}
@@ -158,7 +158,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build manylinux wheels
-      uses: pypa/cibuildwheel@v2.23.1
+      uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_ARCHS: AMD64
         CIBW_BUILD: ${{ matrix.python-tag }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,6 +19,7 @@ jobs:
         - cp311-manylinux_aarch64
         - cp312-manylinux_aarch64
         - cp313-manylinux_aarch64
+        - cp314-manylinux_aarch64
     steps:
     - uses: actions/checkout@v6
       with:
@@ -53,6 +54,7 @@ jobs:
         - cp311-manylinux_x86_64
         - cp312-manylinux_x86_64
         - cp313-manylinux_x86_64
+        - cp314-manylinux_x86_64
     steps:
     - uses: actions/checkout@v6
       with:
@@ -82,12 +84,12 @@ jobs:
     strategy:
       matrix:
         python-tag:
-        - cp38-macosx_x86_64
-        - cp39-macosx_x86_64
-        - cp310-macosx_x86_64
-        - cp311-macosx_x86_64
+          #- cp38-macosx_x86_64
+          #- cp39-macosx_x86_64
+          #- cp310-macosx_x86_64
+          #- cp311-macosx_x86_64
         - cp312-macosx_x86_64
-        - cp313-macosx_x86_64
+          #- cp313-macosx_x86_64
     steps:
     - uses: actions/checkout@v6
       with:
@@ -119,6 +121,39 @@ jobs:
         - cp311-macosx_arm64
         - cp312-macosx_arm64
         - cp313-macosx_arm64
+        - cp314-macosx_arm64
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Build manylinux wheels
+      uses: pypa/cibuildwheel@v3.4.1
+      env:
+        CIBW_ARCHS: arm64
+        CIBW_BUILD: ${{ matrix.python-tag }}
+        CIBW_BEFORE_BUILD: pip install cython pytest
+        CIBW_BUILD_VERBOSITY: 2
+        CIBW_TEST_COMMAND: python -c "import fisher"
+        CIBW_TEST_REQUIRES: importlib-resources
+      with:
+        output-dir: dist
+    - uses: actions/upload-artifact@v7
+      with:
+        name: wheels-${{ matrix.python-tag }}
+        path: dist/*
+
+  wheel-macos-aarch64:
+    name: Build MacOS wheels (Aarch64)
+    runs-on: macos-15
+    strategy:
+      matrix:
+        python-tag:
+        - cp310-macosx_arm64
+        - cp311-macosx_arm64
+        - cp312-macosx_arm64
+        - cp313-macosx_arm64
+        - cp314-macosx_arm64
     steps:
     - uses: actions/checkout@v6
       with:
@@ -152,6 +187,7 @@ jobs:
         - cp311-win_amd64
         - cp312-win_amd64
         - cp313-win_amd64
+        - cp314-win_amd64
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build/
 dist/
 *.pyc
 MANIFEST
+
+# Don't track the Cython source files, since they are generated from .pyx files
+src/*.c


### PR DESCRIPTION
- Update macOS runners: macOS-11 → macos-13 (x86_64), macos-14 (arm64) (macOS-11 runners are deprecated, causing 24h timeout failures)
- Remove deprecated actions-rs/toolchain@v1 (Rust not needed for Python/Cython)
- Fix sdist artifact name: was using matrix.python-tag in a non-matrix job
- Fix test-sdist to download the sdist artifact by its correct name
- Fix upload job: download wheel artifacts by pattern (wheels-*) and sdist separately
- Add cp313 (Python 3.13) to all build matrices
- Update docker/setup-qemu-action v2 → v3