### PR TITLE
Fix two-tailed p-values for extreme tables (#27, #47)

### DIFF
--- a/src/cfisher.pyx
+++ b/src/cfisher.pyx
@@ -96,7 +96,12 @@ cpdef PValues pvalue(int a_true, int a_false, int b_true, int b_false):
     if lm == um:
         return PValues(1.0, 1.0, 1.0)
 
-    cdef double epsilon = 1e-6
+    # Relative tolerance for "at least as extreme as the observed table".
+    # It must be relative: an absolute slack swamps the comparison once the
+    # observed probability drops below it, admitting the whole support and
+    # pinning the two-tailed p-value at the slack itself. R uses the same
+    # 1 + 1e-7 factor in fisher.test.
+    cdef double epsilon = 1e-7
     cdef double cutoff = hypergeometric_probability(k, n, K, N)
     cdef double left_tail = 0, right_tail = 0, two_tail = 0
     cdef int i
@@ -109,7 +114,7 @@ cpdef PValues pvalue(int a_true, int a_false, int b_true, int b_false):
             if x >= k:
                 right_tail += p
 
-            if p <= cutoff + epsilon:
+            if p <= cutoff * (1 + epsilon):
                 two_tail += p
 
     return PValues(min(left_tail, 1.0),

--- a/tests/test_fisher.py
+++ b/tests/test_fisher.py
@@ -50,6 +50,61 @@ def test_pvalue_against_r(table, expected):
 
 
 # ---------------------------------------------------------------------------
+# Extreme tables: two-tailed accuracy far below the old absolute epsilon
+# ---------------------------------------------------------------------------
+# Regression cases for issues #27 and #47. Both were reported as separate
+# bugs but share one cause: the two-tailed sum used an absolute tolerance
+# (p <= cutoff + 1e-6), so once the observed table's probability fell below
+# that slack every table in the support was counted and the result settled
+# at ~1e-6 regardless of the input. Reference values are scipy's
+# fisher_exact, which agrees with R's fisher.test to all printed digits.
+#
+# Each entry: (2x2 table, two_tail, issue)
+EXTREME_CASES = [
+    ([[50, 1], [257, 375]], 1.2220470363522046e-17, "#47"),
+    ([[22, 0], [0, 102]], 7.175066786244522e-25, "#27"),
+]
+
+# The old absolute slack. A pinned result lands just under it; a computed
+# one for these tables is many orders of magnitude smaller, so assert well
+# clear of it rather than merely below.
+OLD_EPSILON_FLOOR = 1e-6
+
+
+@pytest.mark.parametrize("table,expected,issue", EXTREME_CASES)
+def test_two_tail_extreme_tables(table, expected, issue):
+    """Two-tailed p-values must stay accurate below the old 1e-6 slack."""
+    p = pvalue(table[0][0], table[0][1], table[1][0], table[1][1])
+    # Relative, not absolute: an absolute tolerance is vacuous at 1e-17.
+    assert abs(p.two_tail - expected) / expected < 1e-9
+
+
+@pytest.mark.parametrize("table,expected,issue", EXTREME_CASES)
+def test_two_tail_not_pinned_to_epsilon(table, expected, issue):
+    """Guard the specific failure mode: a result stuck at the tolerance."""
+    p = pvalue(table[0][0], table[0][1], table[1][0], table[1][1])
+    assert p.two_tail < OLD_EPSILON_FLOOR * 1e-3
+
+
+@pytest.mark.parametrize("table,expected,issue", EXTREME_CASES)
+def test_extreme_one_tail_unchanged(table, expected, issue):
+    """The one-tailed sums were always correct; they must stay that way."""
+    p = pvalue(table[0][0], table[0][1], table[1][0], table[1][1])
+    # For these tables the two-tailed mass is the right tail alone.
+    assert abs(p.right_tail - expected) / expected < 1e-9
+
+
+def test_two_tail_extreme_via_npy():
+    """pvalue_npy must carry the same accuracy as the scalar interface."""
+    tables = np.array([t for t, _, _ in EXTREME_CASES], dtype=np.uint32)
+    expected = np.array([e for _, e, _ in EXTREME_CASES])
+    twos = pvalue_npy(
+        tables[:, 0, 0], tables[:, 0, 1], tables[:, 1, 0], tables[:, 1, 1]
+    )[2]
+    np.testing.assert_allclose(twos, expected, rtol=1e-9)
+
+
+# ---------------------------------------------------------------------------
 # P-value mathematical properties
 # ---------------------------------------------------------------------------
 class TestPvalueProperties:


### PR DESCRIPTION
Closes #1, closes #27, closes #47. Filed as four separate problems over fourteen years (#26 is a closed duplicate of #27), all with a single cause — and correctly diagnosed in #1 back in 2012.

## The bug

The two-tailed p-value sums every table at least as improbable as the observed one. That selection used an **absolute** tolerance, `src/cfisher.pyx`:

```cython
cdef double epsilon = 1e-6
...
if p <= cutoff + epsilon:
    two_tail += p
```

Once the observed table's probability drops below `epsilon`, `cutoff + epsilon` is just `epsilon`, so the condition admits essentially the whole support. The result then settles at ~1e-6 regardless of the input — it isn't computed, it's pinned to the tolerance. That is exactly what both reporters saw:

| table | reported | scipy / R |
|---|---|---|
| `(50, 1, 257, 375)` — #47 | 1.368624798014e-06 | 1.222047036352e-17 |
| `(22, 0, 0, 102)` — #27 | 8.701019914910e-07 | 7.175066786245e-25 |
| `(94, 48, 3577, 16988)` — #1 | 1.101e-10 (epsilon was 1e-10 then) | 2.069356e-37 |

Each report landed on whatever the epsilon of the day happened to be. The 1e-40 → 1e-10 → 1e-6 adjustments over the years moved the failure around rather than removing it, because the problem was never the size of the slack but its being absolute at all.

## It isn't a precision limit

Worth stating plainly, because #47 was diagnosed as one. The one-tailed sums for both tables are already correct to ~12 significant figures on the current code:

```
pvalue(50, 1, 257, 375).right_tail  = 1.2220470363535e-17   scipy 1.2220470363526e-17
pvalue(22, 0, 0, 102).right_tail    = 7.1750667862446e-25   R     7.175067e-25
```

The hypergeometric probabilities are fine. Only the comparison that decides which of them to add was wrong.

## The fix

Make the tolerance relative, which is what R's `fisher.test` does with the same `1 + 1e-7` factor:

```cython
if p <= cutoff * (1 + epsilon):
```

Both tables then agree with scipy to within 1e-12 relative.

This also supersedes the request in #27 for a user-tunable epsilon — nothing needs `1e-80` once the comparison is scale-free — and the earlier 1e-40 → 1e-6 change, which tried to buy headroom by shrinking an absolute threshold rather than replacing it.

## Tests

Five new regression tests covering both reported tables, scalar and `pvalue_npy`, asserting **relative** error (an absolute tolerance is vacuous at 1e-17). Verified they fail against the pre-fix source and pass with it — note that checking this needs a forced rebuild, as a stale `.so` will silently mask the change.

The twelve existing R-validated cases are unchanged, as are all other tests: 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PGvoQdnXpvY1aYBMDg73A
